### PR TITLE
Adds guidance around dfedigital on Docker Hub

### DIFF
--- a/guides/default-technology-stack.md
+++ b/guides/default-technology-stack.md
@@ -37,7 +37,7 @@ DfE Digital [Azure DevOps](https://azure.microsoft.com/en-gb/services/devops/) (
 
 ### Containerisation
 
-DfE Digital uses Docker to isolate and package up application depedencies from infrastructure and environment concerns.
+DfE Digital uses Docker to isolate and package up application depedencies from infrastructure and environment concerns. All repositories should be added to the [`dfedigital`](https://hub.docker.com/u/dfedigital) Docker Hub organisation. Ask in the `#developers` channel on the DfE Slack to have members added to the DfE Docker Hub organisation and for credentials to use with your CI/CD pipeline.
 
 ## Logging, monitoring and alerting
 


### PR DESCRIPTION
Enforces use of `dfedigital` Docker Hub organisation with guidance on adding members and requesting details.