### PR TITLE
Link back to the repo under "adding guidance"

### DIFF
--- a/index.md
+++ b/index.md
@@ -56,7 +56,7 @@ It is inspired by the [GDS Way](https://gds-way.cloudapps.digital) and the
 
 ## Adding new guidance
 
-Create a new Markdown file that follows this pattern, add a link to it
+Create a new Markdown file in the [DfE Digital technology guidance repo](https://github.com/DFE-Digital/technology-guidance) that follows this pattern, add a link to it
 from this page, and make a pull request:
 
 ```markdown


### PR DESCRIPTION
I don't think it's linked back currently, or at least I didn't find it immediately!