### PR TITLE
Remove blanket recomomendation to verify computed CSS

### DIFF
--- a/principles/frontend-development-principles.md
+++ b/principles/frontend-development-principles.md
@@ -111,9 +111,6 @@ the happy path.
 - You should preferably use your back-end test harness (eg, rspec, unittest) so
 that all the application’s tests are in the same place. Most support browser-based
 tests using webdriver.
-- Don’t just check the text contents of a page, but also check the computed CSS
-(eg. [Money to prisoners](https://github.com/ministryofjustice/money-to-prisoners-cashbook/blob/master/mtp_cashbook/apps/cashbook/tests/test_functional.py#L108)).
-
 
 BDD (using [cucumber](https://cucumber.io/) or any other human-readable way to
 write tests) will only work if your team has the right workflow for it. Unless


### PR DESCRIPTION
CSS is a tool for modifying the presentation of a website.
Asserting whether a CSS class is present doesn't give strong
confidence that a webpage is being presented correctly.
Worse, it makes refactoring class names more painful.

To get confidence that the presentation of a website is correct is
best done either by a human visually inspecting the page, or an
automated visual regression tool.  Neither of which will hinder
refactoring.

I can imagine some scenarios where asserting against the style
of something is important, but these would be outlier cases.